### PR TITLE
Action setpersist by default

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Manages SELinux policy components'
 source_url       'https://github.com/sous-chefs/selinux_policy'
 issues_url       'https://github.com/sous-chefs/selinux_policy/issues'
 chef_version     '>= 13.0'
-version          '2.4.1'
+version          '2.4.2'
 
 supports 'redhat'
 supports 'centos'

--- a/resources/boolean.rb
+++ b/resources/boolean.rb
@@ -4,14 +4,14 @@ property :value, [true, false]
 property :force, [true, false], default: false
 property :allow_disabled, [true, false], default: true
 
-# Set for now, without persisting
-action :set do
-  sebool(new_resource, false)
-end
-
 # Set and persist
 action :setpersist do
   sebool(new_resource, true)
+end
+
+# Set for now, without persisting
+action :set do
+  sebool(new_resource, false)
 end
 
 action_class do


### PR DESCRIPTION
Define in selinux_policy_boolean action :setpersist by default

### Description
Define in selinux_policy_boolean action :setpersist by default, as it is explained in README.md

### Issues Resolved
Fixes #110 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>